### PR TITLE
Fix PHP 8.1 compatibility: Remove typed class constants

### DIFF
--- a/Controller/Adminhtml/Generate/Index.php
+++ b/Controller/Adminhtml/Generate/Index.php
@@ -15,7 +15,7 @@ use MageOS\LlmTxt\Model\StoreDataCollector;
 
 class Index implements HttpPostActionInterface
 {
-    public const string ADMIN_RESOURCE = 'MageOS_LlmTxt::config';
+    public const ADMIN_RESOURCE = 'MageOS_LlmTxt::config';
 
     public function __construct(
         private readonly RequestInterface $request,


### PR DESCRIPTION
## Problem
The module currently fails to compile on PHP 8.1 and 8.2 due to typed class constants (`public const string`), which is a PHP 8.3+ feature.

## Solution
Removes `string` type declaration from `ADMIN_RESOURCE` constant for PHP 8.1+ compatibility.

## Changes
**Before:**
```php
public const string ADMIN_RESOURCE = 'MageOS_LlmTxt::config';
```

**After:**
```php
public const ADMIN_RESOURCE = 'MageOS_LlmTxt::config';
```

## Testing
- [x] Tested on PHP 8.1.33
- [x] Magento 2.4.6-p8
- [x] Compilation successful
- [x] Module functionality unchanged

## Impact
- **Before:** Module only works on PHP 8.3+
- **After:** Module works on PHP 8.1, 8.2, and 8.3 as specified in composer.json

Fixes #5