### PR TITLE
Fix remaining items from module review (#1)

### DIFF
--- a/Client/OpenAi/Client.php
+++ b/Client/OpenAi/Client.php
@@ -17,9 +17,11 @@ class Client
         private readonly Config $config,
     ) {}
 
-    public function postResponses(ResponsesParams $params): string
+    public function postResponses(ResponsesParams $params, ?string $apiKeyOverride = null): string
     {
-        $apiKey = $this->config->getOpenAiApiKey();
+        $apiKey = $apiKeyOverride !== null && $apiKeyOverride !== ''
+            ? $apiKeyOverride
+            : $this->config->getOpenAiApiKey();
         if (empty($apiKey)) {
             throw new \RuntimeException('OpenAI API key is not configured');
         }

--- a/Config/Config.php
+++ b/Config/Config.php
@@ -14,8 +14,6 @@ class Config
     public const XML_PATH_SITE_DESCRIPTION = 'llmtxt/ai_generation/site_description';
     public const XML_PATH_ADDITIONAL_CONTENT = 'llmtxt/ai_generation/additional_content';
     public const XML_PATH_GENERATED_CONTENT = 'llmtxt/content/generated_content';
-    public const XML_PATH_USE_MANUAL = 'llmtxt/content/use_manual_content';
-    public const XML_PATH_MANUAL_CONTENT = 'llmtxt/content/manual_content';
     public const XML_PATH_OPENAI_API_KEY = 'llmtxt/openai/openai_api_key';
     public const XML_PATH_OPENAI_MODEL = 'llmtxt/openai/openai_model';
     public const XML_PATH_CATEGORY_IDS = 'llmtxt/ai_generation/category_ids';
@@ -69,24 +67,6 @@ class Config
     {
         return (string) $this->scopeConfig->getValue(
             self::XML_PATH_GENERATED_CONTENT,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    public function shouldUseManualContent(?int $storeId = null): bool
-    {
-        return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_USE_MANUAL,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    public function getManualContent(?int $storeId = null): string
-    {
-        return (string) $this->scopeConfig->getValue(
-            self::XML_PATH_MANUAL_CONTENT,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Controller/Adminhtml/Generate/Index.php
+++ b/Controller/Adminhtml/Generate/Index.php
@@ -20,6 +20,19 @@ class Index implements HttpPostActionInterface
         private readonly LlmTxtGenerator $llmTxtGenerator,
     ) {}
 
+    private function resolveApiKeyOverride(): ?string
+    {
+        $posted = (string) $this->request->getParam('api_key', '');
+
+        // Obscure fields post back all-asterisks when the user did not edit the field —
+        // treat that as "use the saved key" by falling through to the encrypted config.
+        if ($posted === '' || preg_match('/^\*+$/', $posted) === 1) {
+            return null;
+        }
+
+        return $posted;
+    }
+
     public function execute(): Json
     {
         $result = $this->resultJsonFactory->create();
@@ -30,7 +43,9 @@ class Index implements HttpPostActionInterface
                 $storeId = (int) $this->storeManager->getDefaultStoreView()->getId();
             }
 
-            $generatedContent = $this->llmTxtGenerator->generateLlmTxt($storeId);
+            $apiKeyOverride = $this->resolveApiKeyOverride();
+
+            $generatedContent = $this->llmTxtGenerator->generateLlmTxt($storeId, $apiKeyOverride);
             $tokenCount = $this->llmTxtGenerator->estimateTokenCount($generatedContent);
 
             return $result->setData([

--- a/Service/LlmTxtGenerator.php
+++ b/Service/LlmTxtGenerator.php
@@ -25,7 +25,7 @@ class LlmTxtGenerator
         private readonly ResponsesParamsFactory $responsesParamsFactory,
     ) {}
 
-    public function generateLlmTxt(int $storeId): string
+    public function generateLlmTxt(int $storeId, ?string $apiKeyOverride = null): string
     {
         $storeData = $this->storeDataCollector->collect($storeId);
         $this->validateStoreData($storeData);
@@ -45,7 +45,7 @@ class LlmTxtGenerator
             ->setMaxOutputTokens(self::MAX_OUTPUT_TOKENS)
             ->setTemperature(self::TEMPERATURE);
 
-        $llmTxt = $this->openAiClient->postResponses($params);
+        $llmTxt = $this->openAiClient->postResponses($params, $apiKeyOverride);
 
         $additionalContent = $this->config->getAdditionalContent($storeId);
         if (!empty($additionalContent)) {

--- a/Service/LlmTxtProvider.php
+++ b/Service/LlmTxtProvider.php
@@ -10,10 +10,6 @@ class LlmTxtProvider
 
     public function get(int $storeId): string
     {
-        if ($this->config->shouldUseManualContent($storeId)) {
-            return $this->config->getManualContent($storeId);
-        }
-
         return $this->config->getGeneratedContent($storeId);
     }
 }

--- a/Test/Unit/Config/ConfigTest.php
+++ b/Test/Unit/Config/ConfigTest.php
@@ -110,36 +110,6 @@ final class ConfigTest extends TestCase
         $this->assertSame('# Store\n> Description', $this->config->getGeneratedContent());
     }
 
-    public function test_should_use_manual_content_returns_true_when_flag_is_set(): void
-    {
-        $this->scopeConfig
-            ->method('isSetFlag')
-            ->with(Config::XML_PATH_USE_MANUAL, ScopeInterface::SCOPE_STORE, null)
-            ->willReturn(true);
-
-        $this->assertTrue($this->config->shouldUseManualContent());
-    }
-
-    public function test_should_use_manual_content_returns_false_when_flag_is_not_set(): void
-    {
-        $this->scopeConfig
-            ->method('isSetFlag')
-            ->with(Config::XML_PATH_USE_MANUAL, ScopeInterface::SCOPE_STORE, null)
-            ->willReturn(false);
-
-        $this->assertFalse($this->config->shouldUseManualContent());
-    }
-
-    public function test_get_manual_content_returns_configured_value(): void
-    {
-        $this->scopeConfig
-            ->method('getValue')
-            ->with(Config::XML_PATH_MANUAL_CONTENT, ScopeInterface::SCOPE_STORE, null)
-            ->willReturn('Manual content here');
-
-        $this->assertSame('Manual content here', $this->config->getManualContent());
-    }
-
     public function test_get_openai_api_key_decrypts_stored_value(): void
     {
         $this->scopeConfig

--- a/Test/Unit/Service/LlmTxtProviderTest.php
+++ b/Test/Unit/Service/LlmTxtProviderTest.php
@@ -18,103 +18,32 @@ final class LlmTxtProviderTest extends TestCase
         $this->provider = new LlmTxtProvider($this->config);
     }
 
-    public function test_get_returns_manual_content_when_use_manual_is_enabled(): void
+    public function test_get_returns_generated_content(): void
     {
-        $this->config
-            ->method('shouldUseManualContent')
-            ->with(1)
-            ->willReturn(true);
-
-        $this->config
-            ->method('getManualContent')
-            ->with(1)
-            ->willReturn('# Manual Content\n> Manually written');
-
-        $result = $this->provider->get(1);
-
-        $this->assertSame('# Manual Content\n> Manually written', $result);
-    }
-
-    public function test_get_returns_generated_content_when_use_manual_is_disabled(): void
-    {
-        $this->config
-            ->method('shouldUseManualContent')
-            ->with(1)
-            ->willReturn(false);
-
         $this->config
             ->method('getGeneratedContent')
             ->with(1)
-            ->willReturn('# Generated Content\n> AI written');
+            ->willReturn('# Store\n> AI written');
 
-        $result = $this->provider->get(1);
-
-        $this->assertSame('# Generated Content\n> AI written', $result);
-    }
-
-    public function test_get_does_not_call_get_generated_content_when_manual_is_enabled(): void
-    {
-        $this->config
-            ->method('shouldUseManualContent')
-            ->willReturn(true);
-
-        $this->config
-            ->method('getManualContent')
-            ->willReturn('Manual');
-
-        $this->config
-            ->expects($this->never())
-            ->method('getGeneratedContent');
-
-        $this->provider->get(1);
-    }
-
-    public function test_get_does_not_call_get_manual_content_when_manual_is_disabled(): void
-    {
-        $this->config
-            ->method('shouldUseManualContent')
-            ->willReturn(false);
-
-        $this->config
-            ->method('getGeneratedContent')
-            ->willReturn('Generated');
-
-        $this->config
-            ->expects($this->never())
-            ->method('getManualContent');
-
-        $this->provider->get(1);
+        $this->assertSame('# Store\n> AI written', $this->provider->get(1));
     }
 
     public function test_get_returns_empty_string_when_generated_content_is_empty(): void
     {
         $this->config
-            ->method('shouldUseManualContent')
-            ->willReturn(false);
-
-        $this->config
             ->method('getGeneratedContent')
             ->willReturn('');
 
-        $result = $this->provider->get(1);
-
-        $this->assertSame('', $result);
+        $this->assertSame('', $this->provider->get(1));
     }
 
-    public function test_get_passes_store_id_to_config_methods(): void
+    public function test_get_passes_store_id_to_config(): void
     {
-        $this->config
-            ->method('shouldUseManualContent')
-            ->with(42)
-            ->willReturn(false);
-
         $this->config
             ->method('getGeneratedContent')
             ->with(42)
             ->willReturn('content');
 
-        $result = $this->provider->get(42);
-
-        $this->assertSame('content', $result);
+        $this->assertSame('content', $this->provider->get(42));
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -129,29 +129,14 @@
             </group>
             <group id="content" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>LLMs.txt Content</label>
-                <comment>Review and edit the AI-generated content or write your own</comment>
+                <comment>Review and edit the content served at /llms.txt. Use the "Generate with AI" button to populate it, or write it by hand.</comment>
                 <field id="generated_content" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Generated Content</label>
-                    <comment>This content will be served at /llms.txt. Edit as needed.</comment>
+                    <label>Content</label>
+                    <comment>This content is served at /llms.txt. Edit freely.</comment>
                     <frontend_class>llmtxt-content-editor</frontend_class>
                     <backend_model>MageOS\LlmTxt\Config\Backend\GeneratedContent</backend_model>
                     <depends>
                         <field id="*/*/enabled">1</field>
-                    </depends>
-                </field>
-                <field id="use_manual_content" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Use Manual Content</label>
-                    <comment>Override AI-generated content with your own custom content</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="*/*/enabled">1</field>
-                    </depends>
-                </field>
-                <field id="manual_content" translate="label comment" type="textarea" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Manual Content</label>
-                    <comment>Write your own llms.txt content in markdown format</comment>
-                    <depends>
-                        <field id="use_manual_content">1</field>
                     </depends>
                 </field>
             </group>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,9 +11,6 @@
             <ai_generation>
                 <log_prompt>0</log_prompt>
             </ai_generation>
-            <content>
-                <use_manual_content>0</use_manual_content>
-            </content>
         </llmtxt>
     </default>
 </config>

--- a/view/adminhtml/templates/system/config/generate_button.phtml
+++ b/view/adminhtml/templates/system/config/generate_button.phtml
@@ -7,7 +7,7 @@
     <?= $block->getButtonHtml() ?>
     <div id="llmtxt-generate-status" style="margin-top: 10px;">
         <span class="llmtxt-message">
-            <span style="color: #6d3b00;">⚠️ Save the configuration before generating to ensure all settings are applied.</span>
+            <span>Enter your API key above and click Generate — no need to save first.</span>
         </span>
     </div>
 </div>
@@ -25,6 +25,7 @@ require([
         const button = $(this);
         const statusDiv = $('#llmtxt-generate-status');
         const statusMessage = statusDiv.find('.llmtxt-message');
+        const apiKeyField = $('#llmtxt_openai_openai_api_key');
 
         // Disable button and show loading
         button.prop('disabled', true).addClass('disabled');
@@ -36,7 +37,8 @@ require([
             dataType: 'json',
             data: {
                 form_key: FORM_KEY,
-                store: '<?= (int) $block->getRequest()->getParam('store', 0) ?>'
+                store: '<?= (int) $block->getRequest()->getParam('store', 0) ?>',
+                api_key: apiKeyField.val() || ''
             },
             success: function (response) {
                 if (response.success) {


### PR DESCRIPTION
## Summary

Addresses the two open behavioural items from the module review in #1 that hadn't been covered by the 0.0.1 → 0.1.2 releases.

- **Drop the manual content override** (`use_manual_content` / `manual_content`). The existing `generated_content` textarea was already freely editable after AI generation, so the second content field was duplicative. The admin UI now has one content source.
- **Generate with AI works without saving first.** The button now posts the current OpenAI API-key field value; the controller uses it as an override and falls through to the stored (encrypted) key only when the field is still showing the obscure asterisk placeholder.

Per-field status against the review in #1:

- Cache flush on update — already landed in `7ccc8fd` ✅
- "Custom Markdown Content" field does nothing — already landed in `b0f6ede` ✅
- Cache lifetime option not implemented — setting removed in `1f4ac55` ✅
- API key must be saved before Generate works — **this PR** ✅
- Generate button text looks weird — reworked in `d7ad7a0` / `e06c703` ✅
- Manual content adds no value — **this PR** (removed) ✅

## Test plan

- [x] Installed into a Warden Magento env under `app/code/MageOS/LlmTxt/`
- [x] `bin/magento module:enable MageOS_LlmTxt && setup:upgrade && setup:di:compile` — clean
- [x] `vendor/bin/phpunit app/code/MageOS/LlmTxt/Test/Unit` — 132 tests, 175 assertions, all green
- [x] `/llms.txt` returns 404 when `llmtxt/general/enabled` is 0 (router short-circuits)
- [x] `/llms.txt` returns 200 + `text/plain` + stored content when enabled
- [x] Saving `generated_content` via `bin/magento config:set` invalidates FPC automatically (no manual `cache:flush` needed) — confirms `GeneratedContent::afterSave` still dispatches `clean_cache_by_tags` after the field rename stays intact
- [ ] Manual QA of the admin Generate button with an unsaved API key (reviewer to confirm in a browser)